### PR TITLE
Only highlight standalone numbers in block params

### DIFF
--- a/syntaxes/rst.tmLanguage.json
+++ b/syntaxes/rst.tmLanguage.json
@@ -263,7 +263,7 @@
 						"2": {
 							"patterns": [
 								{
-									"match": "(0x[a-fA-F\\d]+|\\d)",
+									"match": "\\b(0x[a-fA-F\\d]+|\\d+)\\b",
 									"name": "constant.numeric"
 								},
 								{"include": "#inline-markup"}


### PR DESCRIPTION
Requires the number regex to start and end with a word boundary,
preventing block parameters from rendering digits inside words as
numbers.

Fixes #16.