### PR TITLE
fix: Allow top level headings without a child

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,11 @@ class RstSectionProvider implements vscode.DocumentSymbolProvider {
 					}
 				}
 
-				stack[stack.length - 1].children.push(section);
+				if (stack.length === 0) {
+					roots.push(section);
+				} else {
+					stack[stack.length - 1].children.push(section);
+				}
 			} else {
 				roots.push(section);
 				hierarchy.push(section.type);


### PR DESCRIPTION
Opening a document like below with v1.5.2 causes a problem reported in the issue https://github.com/trond-snekvik/vscode-rst/issues/32:

```restructuredtext
Foo
===

Bar
===
```

This PR should fix the problem.