### PR TITLE
Fix deeply nested blocks

### DIFF
--- a/syntaxes/rst.tmLanguage.json
+++ b/syntaxes/rst.tmLanguage.json
@@ -234,7 +234,7 @@
 		},
 		"block": {
 			"begin": "^(\\s*)(\\.{2}\\s+\\S+::)(.*)",
-			"while": "^\\1(?=\\s)|^\\s*$",
+			"end": "^(?!\\1\\s|\\s*$)",
 			"beginCaptures": {
 				"2": {
 					"name": "keyword.control"

--- a/syntaxes/test/_nested-blocks.rst
+++ b/syntaxes/test/_nested-blocks.rst
@@ -1,0 +1,25 @@
+-- SYNTAX TEST "source.rst" "nested blocks"
+
+:param: abc
+-- <----- -keyword.control
+
+.. note:: aa
+-- <--------- keyword.control
+
+  :param: abc
+--^^^^^^^ keyword.control
+
+  .. note:: b
+--^^^^^^^^^ keyword.control
+
+    .. note:: c
+--  ^^^^^^^^^ keyword.control
+
+    .. comment c
+--  ^^^^^^^^^^^^ comment.block
+
+  .. comment b
+--^^^^^^^^^^^^ comment.block
+
+.. comment a
+-- <------------ comment.block


### PR DESCRIPTION
Switches the blocks scope to using a negative lookahead end pattern matcher instead of the while pattern.

Fixes #37.