### PR TITLE
make options-list word regex oneshot

### DIFF
--- a/syntaxes/rst.tmLanguage.json
+++ b/syntaxes/rst.tmLanguage.json
@@ -184,7 +184,7 @@
 			"name": "entity.name.tag"
 		},
 		"options-list": {
-			"match": "^((?:-\\w|--[\\w-]+|/\\w+)(?:,? ?[\\w-]+)*)(?:  |\\t|$)",
+			"match": "^((?:-\\w|--[\\w-]+|/\\w+)(?:,? ?[\\w-]++)*)(?:  |\\t|$)",
 			"name": "variable.parameter"
 		},
 		"blocks": {


### PR DESCRIPTION
this prevents catastrophic backtracking by using a possessive quantifier

resolves #40